### PR TITLE
feat: Request to add Atlas cluster - backstage

### DIFF
--- a/atlas-crds/atlas-deployment-skeleton.yaml
+++ b/atlas-crds/atlas-deployment-skeleton.yaml
@@ -1,0 +1,18 @@
+# /backstage-templates/atlas-cluster/skeleton/atlas-deployment-skeleton.yaml
+apiVersion: atlas.mongodb.com/v1
+kind: AtlasDeployment
+metadata:
+  name: my-atlas-cluster
+  namespace: mongodb-atlas-operator # Or make this a parameter
+  labels:
+    environment: development
+    # owner: 
+spec:
+  projectName: paulcheong-project-k8s # Assumes project already exists
+  deploymentSpec:
+    name: backstage
+    providerSettings:
+      instanceSizeName: M10 # e.g., M10, M20
+      providerName: AWS # e.g., AWS, GCP, AZURE
+      regionName: US_EAST_1
+  # Add other necessary spec fields like backup, BI connector, etc.

--- a/atlas-crds/catalog-info.yaml
+++ b/atlas-crds/catalog-info.yaml
@@ -1,0 +1,12 @@
+# /backstage-templates/atlas-cluster-skeleton/catalog-info.yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-config # Templated
+  description: Atlas cluster configuration for backstage # Templated
+  annotations:
+    github.com/project-slug: positive-mental-attitude/backstage-config # Templated
+spec:
+  type: service-configuration
+  lifecycle: development # Templated
+  # owner:  # Removed owner


### PR DESCRIPTION
Please review and merge this Pull Request to add the AtlasDeployment CRD for cluster:
- Kubernetes CR Name: `my-atlas-cluster`
- Atlas UI Name: `backstage`
- Environment: `development`
- Target Atlas Project (K8s Name): `paulcheong-project-k8s`

This CRD will be deployed to the `/atlas-crds/` directory.
The full configuration is also available in its dedicated repository: https://github.com/positive-mental-attitude/backstage-config.git
