### PR TITLE
feat: Request to add Atlas cluster - backstage-test

### DIFF
--- a/atlas-crds/atlas-deployment-skeleton.yaml
+++ b/atlas-crds/atlas-deployment-skeleton.yaml
@@ -2,7 +2,7 @@
 apiVersion: atlas.mongodb.com/v1
 kind: AtlasDeployment
 metadata:
-  name: my-atlas-cluster
+  name: app-backstage-test
   # namespace: mongodb-atlas-operator # Or make this a parameter
   labels:
     environment: development
@@ -10,7 +10,7 @@ metadata:
 spec:
   projectName: paulcheong-project-k8s 
   deploymentSpec:
-    name: backstage
+    name: backstage-test
     providerSettings:
       instanceSizeName: M10 # e.g., M10, M20
       providerName: AWS # e.g., AWS, GCP, AZURE


### PR DESCRIPTION
Please review and merge this Pull Request to add the AtlasDeployment CRD for cluster:
- Atlas UI Name: `backstage-test`
- Environment: `development`

This CRD will be deployed to the `/atlas-crds/` directory.
The full configuration is also available in its dedicated repository: https://github.com/positive-mental-attitude/backstage-test-config.git
