### PR TITLE
feat: Request to add Atlas cluster - backstage

### DIFF
--- a/atlas-crds/atlas-deployment-skeleton.yaml
+++ b/atlas-crds/atlas-deployment-skeleton.yaml
@@ -1,0 +1,18 @@
+# /backstage-templates/atlas-cluster/skeleton/atlas-deployment-skeleton.yaml
+apiVersion: atlas.mongodb.com/v1
+kind: AtlasDeployment
+metadata:
+  name: backstage
+  # namespace: mongodb-atlas-operator # Or make this a parameter
+  labels:
+    environment: development
+    # owner: 
+spec:
+  projectName: paulcheong-project-k8s 
+  deploymentSpec:
+    name: backstage
+    providerSettings:
+      instanceSizeName: M10 # e.g., M10, M20
+      providerName: AWS # e.g., AWS, GCP, AZURE
+      regionName: US_EAST_1
+  # Add other necessary spec fields like backup, BI connector, etc.


### PR DESCRIPTION
Please review and merge this Pull Request to add the AtlasDeployment CRD for cluster:
- Atlas UI Name: `backstage`
- Environment: `development`

This CRD will be deployed to the `/atlas-crds/` directory.
The full configuration is also available in its dedicated repository: https://github.com/positive-mental-attitude/backstage-config.git
