### PR TITLE
feat: Request to add Atlas cluster - qwerty

### DIFF
--- a/atlas-crds/atlas-deployment-skeleton.yaml
+++ b/atlas-crds/atlas-deployment-skeleton.yaml
@@ -1,0 +1,25 @@
+# /backstage-templates/atlas-cluster/skeleton/atlas-deployment-skeleton.yaml
+apiVersion: atlas.mongodb.com/v1
+kind: AtlasDeployment
+metadata:
+  name: qwerty-deployment
+  labels:
+    environment: development
+spec:
+  projectRef: 
+    name: paulcheong-project-k8s 
+  deploymentSpec:
+    clusterType: REPLICASET
+    tags:
+      - key: "environment"
+        value: "development"
+    name: "qwerty"
+    replicationSpecs:
+      - zoneName: US-Zone
+        regionConfigs:
+          - electableSpecs:
+              instanceSize: M10
+              nodeCount: 3
+            providerName: AWS
+            regionName: US_EAST_1
+            priority: 7


### PR DESCRIPTION
Please review and merge this Pull Request to add the AtlasDeployment CRD for cluster:
- Atlas UI Name: `qwerty`
- Environment: `development`

This CRD will be deployed to the `/atlas-crds/` directory.
The full configuration is also available in its dedicated repository: https://github.com/positive-mental-attitude/qwerty-config.git
